### PR TITLE
remove unnecessary provider version lockdown

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">=1.2.3"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.22.0"
+      source = "hashicorp/azurerm"
     }
   }
 }


### PR DESCRIPTION
### Change description

Unnecessarily requiring a version 4+ azureRM is causing compatibility issues with the cpp subnet module which is using params from azureRM 3.50.0.

Sorry!

Tests pass locally without the requirement.