### PR TITLE
DTSPO-31040 - Update agent pool to new CIS-hardened Ubuntu VMSS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
 extends:
   template: pipelines/terratest.yaml@cppAzureDevOpsTemplates
   parameters:
-    agentPool: "MDV-ADO-AGENTS-01"
+    agentPool: "ubuntu-ado-agents-mdv"
     spnCredentialsVarGroup: "terratest-app-registration"
     azureServiceConnection: "ado_nonlive_service_principal_lab"
     terratestTimeout: "30"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -24,10 +24,20 @@ module "registry" {
 }
 
 
+# Dedicated resource group for the network so the VNet/subnet have an explicit
+# dependency on a resource group that Terraform creates first. Referencing the
+# module's resource group by name string gives no dependency edge, which races
+# the module's RG creation and intermittently fails with ResourceGroupNotFound.
+resource "azurerm_resource_group" "network" {
+  name     = "${var.vnet_name}-${var.postfix}-rg"
+  location = var.location
+  tags     = local.tags
+}
+
 resource "azurerm_virtual_network" "test" {
   name                = "${var.vnet_name}-${var.postfix}"
   location            = var.location
-  resource_group_name = "${var.resource_group_name}${var.postfix}"
+  resource_group_name = azurerm_resource_group.network.name
   address_space       = ["10.0.0.0/16"]
   dns_servers         = ["10.0.0.4", "10.0.0.5"]
   tags                = local.tags
@@ -35,7 +45,7 @@ resource "azurerm_virtual_network" "test" {
 
 resource "azurerm_subnet" "test" {
   name                                          = "example-subnet"
-  resource_group_name                           = "${var.resource_group_name}${var.postfix}"
+  resource_group_name                           = azurerm_resource_group.network.name
   virtual_network_name                          = azurerm_virtual_network.test.name
   address_prefixes                              = ["10.0.1.0/24"]
   private_link_service_network_policies_enabled = false


### PR DESCRIPTION

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31040

### Change description

Replace end-of-life MDV-ADO-AGENTS-01 pool with the new ubuntu-ado-agents-mdv VMSS pool in the pipeline.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
